### PR TITLE
feat: override mainnet release

### DIFF
--- a/config/networks.go
+++ b/config/networks.go
@@ -35,7 +35,7 @@ func NetworkConfigForEnvironmentName(envName string) (*Network, error) {
 var (
 	Mainnet = Network{
 		ArtifactsRepository: "vegaprotocol/vega",
-		BinaryVersionOverride: "v0.75.8-fix.1",
+		BinaryVersionOverride: "v0.75.8-fix.2",
 		GenesisURL:          "https://raw.githubusercontent.com/vegaprotocol/networks/master/mainnet1/genesis.json",
 		DataNodesREST: []string{
 			"https://api0.vega.community",


### PR DESCRIPTION
# Testing

```
 go run main.go run --environment mainnet --duration 4m
 
 ...
 ...
 
2024-05-25T12:08:20.221+0200	info	watchdog	Core blocks lag too big: local core(47929861) is 1001 blocks behind rest of the network(47930862), 500 blocks allowed
2024-05-25T12:08:25.924+0200	info	watchdog	Core blocks lag too big: local core(47930007) is 862 blocks behind rest of the network(47930869), 500 blocks allowed
2024-05-25T12:08:31.543+0200	info	watchdog	Core blocks lag too big: local core(47930136) is 742 blocks behind rest of the network(47930878), 500 blocks allowed
2024-05-25T12:08:37.163+0200	info	watchdog	Core blocks lag too big: local core(47930275) is 612 blocks behind rest of the network(47930887), 500 blocks allowed
2024-05-25T12:08:42.771+0200	info	watchdog	Node caught rest of the network up at block 47930410
2024-05-25T12:08:48.392+0200	info	watchdog	Local node is healthy, block is 47930536
2024-05-25T12:08:50.819+0200	info	Snapshot testing finished after 4m0s
2024-05-25T12:08:50.819+0200	info	Result: {
    "catchup-duration": "3m52.578810408s",
    "last-known-node-height": 47930536,
    "network-stopped-producing blocks": "0001-01-01 00:00:00 +0000 UTC",
    "node-catch-up": "2024-05-25 12:08:42.77171539 +0200 CEST m=+248.659229301",
    "node-last-healthy": "2024-05-25 12:08:48.392024529 +0200 CEST m=+254.279538420",
    "node-last-lag": "2024-05-25 12:08:37.163909302 +0200 CEST m=+243.051423203",
    "node-startup": "2024-05-25 12:06:36.688645527 +0200 CEST m=+122.576035023",
    "reason": "",
    "status": "HEALTHY",
    "test-startup": "2024-05-25 12:04:50.19321437 +0200 CEST m=+16.080418893",
    "visor-extra-log-lines": ""
}
2024-05-25T12:08:50.819+0200	info	Writing results to the /tmp/snapshot-testing/results.json file
 ```